### PR TITLE
[SWS-106] 로그인 UI 수정 및 레트로핏 인터셉터 설정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,7 +22,9 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Client"
         tools:targetApi="31"
-        android:usesCleartextTraffic="true">
+        android:usesCleartextTraffic="true"
+        android:name=".MainApplication"
+        >
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/app/src/main/java/com/ite/sws/MainActivity.kt
+++ b/app/src/main/java/com/ite/sws/MainActivity.kt
@@ -12,6 +12,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.ui.setupWithNavController
 import com.ite.sws.databinding.ActivityMainBinding
 import com.ite.sws.domain.cart.view.ui.ContainerFragment
+import com.ite.sws.domain.member.view.ui.LoginFragment
 import com.ite.sws.util.SharedPreferencesUtil
 
 /**
@@ -25,8 +26,9 @@ import com.ite.sws.util.SharedPreferencesUtil
  * ----------  --------    ---------------------------
  * 2024.08.24  	정은지       최초 생성 및 네비게이션바 추가
  * 2024.08.31   정은지       화면 전환에 따른 FAB 아이콘 및 배경 변경
- * 2024.09.01   김민정       ContainerFragment로 시작 프래그먼트        
+ * 2024.09.01   김민정       ContainerFragment로 시작 프래그먼트
  * 2024.09.02   남진수       딥링크 연결 처리
+ * 2024.09.03   정은지       로그인 여부에 따른 화면 이동 처리
  * </pre>
  */
 class MainActivity : AppCompatActivity() {
@@ -37,6 +39,7 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
 
         binding = ActivityMainBinding.inflate(layoutInflater)
+
         setContentView(binding.root)
 
         binding.navigationMain.itemIconTintList = null
@@ -47,10 +50,11 @@ class MainActivity : AppCompatActivity() {
             binding.navigationMain.setupWithNavController(it)
         }
 
+        // 딥링크 처리
         intent?.let { handleDeeplink(it) }
 
         // 화면 전환 시 FAB 아이콘 및 배경 변경
-        navController?.addOnDestinationChangedListener() { _, destination, _ ->
+        navController?.addOnDestinationChangedListener { _, destination, _ ->
             when (destination.id) {
                 R.id.navigation_container -> {
                     // 스캔앤고 메뉴가 선택되었을 때
@@ -58,7 +62,6 @@ class MainActivity : AppCompatActivity() {
                     binding.btnScan.backgroundTintList =
                         ContextCompat.getColorStateList(this, R.color.main)
                 }
-
                 else -> {
                     // 다른 메뉴가 선택되었을 때
                     binding.btnScan.setImageResource(R.drawable.ic_nav_scan_off)
@@ -68,13 +71,26 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
+        val accessToken = SharedPreferencesUtil.getAccessToken()
+        if (accessToken.isNullOrEmpty()) {
+            // 액세스 토큰이 없으면 로그인 화면으로 이동
+            supportFragmentManager.beginTransaction()
+                .replace(R.id.container_main, LoginFragment())
+                .addToBackStack(null)
+                .commit()
+            return
+        }
+
+        // 액세스 토큰이 있을 경우
+        // 네비게이션 설정
+        // 초기 프래그먼트 설정
         if (savedInstanceState == null) {
             supportFragmentManager.beginTransaction()
                 .replace(R.id.fragment_container, ContainerFragment())
                 .commit()
         }
-
     }
+
 
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
@@ -98,7 +114,6 @@ class MainActivity : AppCompatActivity() {
             }
         }
     }
-
 
     private fun navigateToCart(cartId: Long) {
         val navController =

--- a/app/src/main/java/com/ite/sws/MainApplication.kt
+++ b/app/src/main/java/com/ite/sws/MainApplication.kt
@@ -3,6 +3,18 @@ package com.ite.sws
 import android.app.Application
 import com.ite.sws.util.SharedPreferencesUtil
 
+/**
+ * 전역 상태 관리를 위한 클래스
+ * @author 정은지
+ * @since 2024.09.03
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        	수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.09.03  	정은지       최초 생성
+ * </pre>
+ */
 class MainApplication : Application() {
     override fun onCreate() {
         super.onCreate()

--- a/app/src/main/java/com/ite/sws/MainApplication.kt
+++ b/app/src/main/java/com/ite/sws/MainApplication.kt
@@ -1,0 +1,11 @@
+package com.ite.sws
+
+import android.app.Application
+import com.ite.sws.util.SharedPreferencesUtil
+
+class MainApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        SharedPreferencesUtil.init(this)
+    }
+}

--- a/app/src/main/java/com/ite/sws/common/RetrofitClient.kt
+++ b/app/src/main/java/com/ite/sws/common/RetrofitClient.kt
@@ -2,6 +2,9 @@ package com.ite.sws.common
 
 import com.ite.sws.BuildConfig
 import com.google.gson.GsonBuilder
+import com.ite.sws.util.SharedPreferencesUtil
+import okhttp3.OkHttpClient
+import okhttp3.Request
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
@@ -15,15 +18,34 @@ import retrofit2.converter.gson.GsonConverterFactory
  * 수정일        	수정자        수정내용
  * ----------  --------    ---------------------------
  * 2024.08.31  	정은지       최초 생성
+ * 2024.09.02   정은지       인터셉터 설정
+ *
  * </pre>
  */
 
 object RetrofitClient {
     private const val BASE_URL = BuildConfig.BASE_URL
 
+    // OkHttpClient 설정
+    val httpClient: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                val requestBuilder: Request.Builder = chain.request().newBuilder()
+                // SharedPreferencesUtil에서 액세스 토큰 가져오기
+                val accessToken = SharedPreferencesUtil.getAccessToken()
+                // 액세스 토큰이 있으면 헤더에 추가
+                if (!accessToken.isNullOrEmpty()) {
+                    requestBuilder.addHeader("Authorization", "Bearer $accessToken")
+                }
+                chain.proceed(requestBuilder.build())
+            }
+            .build()
+    }
+
     val instance: Retrofit by lazy {
         Retrofit.Builder()
             .baseUrl(BASE_URL)
+            .client(httpClient)
             .addConverterFactory(GsonConverterFactory.create(GsonBuilder().setLenient().create()))
             .build()
     }

--- a/app/src/main/java/com/ite/sws/domain/member/api/repository/MemberRepository.kt
+++ b/app/src/main/java/com/ite/sws/domain/member/api/repository/MemberRepository.kt
@@ -26,7 +26,7 @@ import com.ite.sws.domain.member.data.GetMemberRes
  * 2024.08.31   정은지        최초 생성
  * </pre>
  */
-class MemberRepository(private val context: Context) {
+class MemberRepository {
 
     private val memberService =
         RetrofitClient.instance.create(MemberService::class.java)
@@ -44,8 +44,8 @@ class MemberRepository(private val context: Context) {
             override fun onResponse(call: Call<JwtToken>, response: Response<JwtToken>) {
                 if (response.isSuccessful) {
                     response.body()?.let { jwtToken ->
-                        // 로그인 성공 시 토큰 SharedPreferences에 저장
-                        SharedPreferencesUtil.saveString(context, "jwt_token", jwtToken.accessToken)
+                        // 로그인 성공 시 액세스 토큰을 SharedPreferences에 저장
+                        SharedPreferencesUtil.setAccessToken(jwtToken.accessToken)
                         onSuccess()
                     }
 
@@ -71,44 +71,44 @@ class MemberRepository(private val context: Context) {
     /**
      * 마이페이지 정보 요청
      */
-//    fun getMyPageInfo(
-//        onSuccess: (GetMemberRes) -> Unit,
-//        onFailure: (ErrorRes) -> Unit
-//    ) {
-//        // SharedPreferences에서 JWT 토큰을 가져오기
-//        val token = SharedPreferencesUtil.getString(context, "jwt_token")
-//
-//        // 토큰이 null이 아닌 경우에만 요청 수행
-//        if (token != null) {
-//            val authHeader = "Bearer $token"
-//            val call = memberService.getMyPageInfo(authHeader)
-//
-//            call.enqueue(object : Callback<GetMemberRes> {
-//                override fun onResponse(call: Call<GetMemberRes>, response: Response<GetMemberRes>) {
-//                    if (response.isSuccessful) {
-//                        response.body()?.let {
-//                            onSuccess(it)
-//                        }
-//                    } else {
-//                        val errorBodyString = response.errorBody()?.string()
-//                        val errorRes = Gson().fromJson(errorBodyString, ErrorRes::class.java)
-//                        onFailure(errorRes)
-//                    }
-//                }
-//
-//                override fun onFailure(call: Call<GetMemberRes>, t: Throwable) {
-//                    t.printStackTrace()
-//                    val networkError = ErrorRes(
-//                        status = 0,
-//                        errorCode = "NETWORK_ERROR",
-//                        message = t.localizedMessage ?: "Unknown network error"
-//                    )
-//                    onFailure(networkError)
-//                }
-//            })
-//        } else {
-//            // 토큰이 없을 경우 실패 처리
-//            onFailure(ErrorRes(0, "NO_TOKEN", "JWT 토큰이 없습니다."))
-//        }
-//    }
+    fun getMyPageInfo(
+        onSuccess: (GetMemberRes) -> Unit,
+        onFailure: (ErrorRes) -> Unit
+    ) {
+        // SharedPreferences에서 JWT 토큰을 가져오기
+        val token = SharedPreferencesUtil.getAccessToken()
+
+        // 토큰이 null이 아닌 경우에만 요청 수행
+        if (token != null) {
+            val authHeader = "Bearer $token"
+            val call = memberService.getMyPageInfo(authHeader)
+
+            call.enqueue(object : Callback<GetMemberRes> {
+                override fun onResponse(call: Call<GetMemberRes>, response: Response<GetMemberRes>) {
+                    if (response.isSuccessful) {
+                        response.body()?.let {
+                            onSuccess(it)
+                        }
+                    } else {
+                        val errorBodyString = response.errorBody()?.string()
+                        val errorRes = Gson().fromJson(errorBodyString, ErrorRes::class.java)
+                        onFailure(errorRes)
+                    }
+                }
+
+                override fun onFailure(call: Call<GetMemberRes>, t: Throwable) {
+                    t.printStackTrace()
+                    val networkError = ErrorRes(
+                        status = 0,
+                        errorCode = "NETWORK_ERROR",
+                        message = t.localizedMessage ?: "Unknown network error"
+                    )
+                    onFailure(networkError)
+                }
+            })
+        } else {
+            // 토큰이 없을 경우 실패 처리
+            onFailure(ErrorRes(0, "NO_TOKEN", "JWT 토큰이 없습니다."))
+        }
+    }
 }

--- a/app/src/main/java/com/ite/sws/domain/member/api/repository/MemberRepository.kt
+++ b/app/src/main/java/com/ite/sws/domain/member/api/repository/MemberRepository.kt
@@ -24,6 +24,8 @@ import com.ite.sws.domain.member.data.GetMemberRes
  * 수정일        수정자        수정내용
  * ----------  --------    ---------------------------
  * 2024.08.31   정은지        최초 생성
+ * 2024.08.31   정은지        로그인 추가
+ * 2024.09.02   정은지        회원 정보 조회 추가
  * </pre>
  */
 class MemberRepository {
@@ -80,8 +82,7 @@ class MemberRepository {
 
         // 토큰이 null이 아닌 경우에만 요청 수행
         if (token != null) {
-            val authHeader = "Bearer $token"
-            val call = memberService.getMyPageInfo(authHeader)
+            val call = memberService.getMyPageInfo()
 
             call.enqueue(object : Callback<GetMemberRes> {
                 override fun onResponse(call: Call<GetMemberRes>, response: Response<GetMemberRes>) {

--- a/app/src/main/java/com/ite/sws/domain/member/api/service/MemberService.kt
+++ b/app/src/main/java/com/ite/sws/domain/member/api/service/MemberService.kt
@@ -27,7 +27,7 @@ interface MemberService {
     fun login(@Body loginRequest: PostLoginReq
     ): Call<JwtToken>
 
-//    @GET("/members")
-//    fun getMyPageInfo(@Header("Authorization") authHeader: String
-//    ): Call<GetMemberRes>
+    @GET("/members")
+    fun getMyPageInfo(@Header("Authorization") authHeader: String
+    ): Call<GetMemberRes>
 }

--- a/app/src/main/java/com/ite/sws/domain/member/api/service/MemberService.kt
+++ b/app/src/main/java/com/ite/sws/domain/member/api/service/MemberService.kt
@@ -19,6 +19,8 @@ import retrofit2.http.POST
  * 수정일        수정자        수정내용
  * ----------  --------    ---------------------------
  * 2024.08.31   정은지        최초 생성
+ * 2024.08.31   정은지        로그인 API 호출
+ * 2024.09.02   정은지        회원 정보 조회 API 호출
  * </pre>
  */
 interface MemberService {
@@ -28,6 +30,5 @@ interface MemberService {
     ): Call<JwtToken>
 
     @GET("/members")
-    fun getMyPageInfo(@Header("Authorization") authHeader: String
-    ): Call<GetMemberRes>
+    fun getMyPageInfo(): Call<GetMemberRes>
 }

--- a/app/src/main/java/com/ite/sws/domain/member/view/ui/LoginFragment.kt
+++ b/app/src/main/java/com/ite/sws/domain/member/view/ui/LoginFragment.kt
@@ -9,15 +9,24 @@ import androidx.fragment.app.Fragment
 import com.ite.sws.MainActivity
 import com.ite.sws.R
 import com.ite.sws.databinding.FragmentLoginBinding
-import com.ite.sws.domain.cart.view.ui.ContainerFragment
 import com.ite.sws.domain.member.api.repository.MemberRepository
 import com.ite.sws.domain.member.data.PostLoginReq
 import com.ite.sws.util.CustomDialog
-import com.ite.sws.util.SharedPreferencesUtil
 import com.ite.sws.util.hideBottomNavigation
 import com.ite.sws.util.replaceFragmentWithAnimation
-import setupToolbar
 
+/**
+ * 로그인 프래그먼트
+ * @author 정은지
+ * @since 2024.09.02
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        	수정자       수정내용
+ * ----------  --------    ---------------------------
+ * 2024.09.02   정은지       최초 생성
+ * </pre>
+ */
 class LoginFragment : Fragment() {
 
     private var _binding: FragmentLoginBinding? = null

--- a/app/src/main/java/com/ite/sws/domain/member/view/ui/LoginFragment.kt
+++ b/app/src/main/java/com/ite/sws/domain/member/view/ui/LoginFragment.kt
@@ -9,8 +9,10 @@ import androidx.fragment.app.Fragment
 import com.ite.sws.MainActivity
 import com.ite.sws.R
 import com.ite.sws.databinding.FragmentLoginBinding
+import com.ite.sws.domain.cart.view.ui.ContainerFragment
 import com.ite.sws.domain.member.api.repository.MemberRepository
 import com.ite.sws.domain.member.data.PostLoginReq
+import com.ite.sws.util.CustomDialog
 import com.ite.sws.util.SharedPreferencesUtil
 import com.ite.sws.util.hideBottomNavigation
 import com.ite.sws.util.replaceFragmentWithAnimation
@@ -20,14 +22,12 @@ class LoginFragment : Fragment() {
 
     private var _binding: FragmentLoginBinding? = null
     private val binding get() = _binding!!
-    private lateinit var memberRepository: MemberRepository
+    private val memberRepository = MemberRepository()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-
-        memberRepository = MemberRepository(requireContext())
 
         _binding = FragmentLoginBinding.inflate(inflater, container, false)
 
@@ -49,7 +49,7 @@ class LoginFragment : Fragment() {
 
         // 회원가입 버튼 클릭
         binding.tvSignup.setOnClickListener {
-//            replaceFragmentWithAnimation(R.id.container_main, SignUpFragment(), true)
+            replaceFragmentWithAnimation(R.id.container_main, SignUpFragment(), true)
         }
     }
 
@@ -68,14 +68,19 @@ class LoginFragment : Fragment() {
         val postLoginReq = PostLoginReq(loginId, password)
 
         memberRepository.login(postLoginReq,
+            // 성공 시 메인 화면으로 이동
             onSuccess = {
-                // TODO 이전 화면으로 돌아가기
-                val token = SharedPreferencesUtil.getString(requireContext(), "jwt_token")
-                Toast.makeText(requireContext(), "로그인 성공 $token", Toast.LENGTH_SHORT).show()
+                parentFragmentManager.popBackStack()
             },
+
+            // 실패 시 로그인 실패 모달
             onFailure = { errorRes ->
-                // TODO 로그인 실패 모달
-                Toast.makeText(requireContext(), "로그인 실패: ${errorRes.message}", Toast.LENGTH_SHORT).show()
+                CustomDialog(
+                    layoutId = R.layout.dialog_text1_btn1,
+                    title = "${errorRes.message}",
+                    confirmText = "확인",
+                    onConfirm = {}
+                ).show(activity?.supportFragmentManager!!, "CustomDialog")
             }
         )
     }

--- a/app/src/main/java/com/ite/sws/domain/member/view/ui/MypageFragment.kt
+++ b/app/src/main/java/com/ite/sws/domain/member/view/ui/MypageFragment.kt
@@ -5,12 +5,12 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import com.ite.sws.MainActivity
 import com.ite.sws.R
 import com.ite.sws.databinding.FragmentMypageBinding
 import com.ite.sws.domain.member.api.repository.MemberRepository
+import com.ite.sws.util.CustomDialog
 import com.ite.sws.util.hideBottomNavigation
 import com.ite.sws.util.replaceFragmentWithAnimation
 import setupToolbar
@@ -25,21 +25,20 @@ import setupToolbar
  * 수정일        	수정자       수정내용
  * ----------  --------    ---------------------------
  * 2024.08.24  	정은지       최초 생성
+ * 2024.09.03   정은지       버튼 클릭 리스너 설정
  * </pre>
  */
 class MypageFragment : Fragment() {
 
     private var _binding: FragmentMypageBinding? = null
     private val binding get() = _binding!!
-    private lateinit var memberRepository: MemberRepository
+    private val memberRepository = MemberRepository()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
         _binding = FragmentMypageBinding.inflate(inflater, container, false)
-
-        memberRepository = MemberRepository(requireContext())
 
         getMyPageInfo()
 
@@ -56,14 +55,9 @@ class MypageFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        // 로그인 테스트
-        binding.login.setOnClickListener {
-            replaceFragmentWithAnimation(R.id.container_main, LoginFragment(), addToBackStack = true)
-        }
-
         // 리뷰 관리 버튼 클릭
         binding.btnReview.setOnClickListener {
-            replaceFragmentWithAnimation(R.id.container_main, MyReviewFragment(), addToBackStack = true)
+            replaceFragmentWithAnimation(R.id.container_main, MyReviewFragment(), true)
         }
 
         // 업데이트 버튼 클릭
@@ -83,31 +77,32 @@ class MypageFragment : Fragment() {
 
         // 회원탈퇴 버튼 클릭
         binding.btnWithdraw.setOnClickListener {
-//            showCustomDialog(
-//                context = requireContext(),
-//                title = "정말로 탈퇴하시겠어요?",
-//                message = "탈퇴 시 작성한 리뷰는 모두 삭제됩니다.",
-//                layoutId = R.layout.dialog_title_message_twobtn,
-//                confirmText = "탈퇴",
-//                cancelText = "취소",
-//                onConfirm = {
-//                    // TODO 탈퇴 처리 API
-//                },
-//                onCancel = {}
-//            )
+            CustomDialog(
+                layoutId = R.layout.dialog_text2_btn2,
+                title = "정말로 탈퇴하시겠어요?",
+                message = "탈퇴 시 작성한 리뷰는 모두 삭제됩니다.",
+                confirmText = "탈퇴",
+                cancelText = "취소",
+                onConfirm = {
+                    // TODO 탈퇴 처리 API
+                },
+                onCancel = {}
+            ).show(activity?.supportFragmentManager!!, "CustomDialog")
         }
     }
 
     private fun getMyPageInfo() {
-//        memberRepository.getMyPageInfo(
-//            onSuccess = { memberInfo ->
-//                // 사용자 이름을 TextView에 설정
-//                binding.tvName.text = memberInfo.name
-//            },
-//            onFailure = { errorRes ->
-//                Toast.makeText(requireContext(), "정보를 가져오지 못했습니다: ${errorRes.message}", Toast.LENGTH_SHORT).show()
-//            }
-//        )
+        memberRepository.getMyPageInfo(
+            onSuccess = { memberInfo ->
+                // 사용자 이름을 TextView에 설정
+                binding?.let {
+                    binding.tvName.text = memberInfo.name +"님"
+                }
+            },
+            onFailure = { errorRes ->
+                Toast.makeText(requireContext(), "정보를 가져오지 못했습니다: ${errorRes.message}", Toast.LENGTH_SHORT).show()
+            }
+        )
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/ite/sws/domain/member/view/ui/SignUpFragment.kt
+++ b/app/src/main/java/com/ite/sws/domain/member/view/ui/SignUpFragment.kt
@@ -10,6 +10,18 @@ import com.ite.sws.databinding.FragmentSignupBinding
 import com.ite.sws.domain.member.api.repository.MemberRepository
 import com.ite.sws.util.hideBottomNavigation
 
+/**
+ * 회원가입 프래그먼트
+ * @author 정은지
+ * @since 2024.09.02
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        	수정자       수정내용
+ * ----------  --------    ---------------------------
+ * 2024.09.02   정은지       최초 생성
+ * </pre>
+ */
 class SignUpFragment : Fragment() {
 
     private var _binding: FragmentSignupBinding? = null

--- a/app/src/main/java/com/ite/sws/domain/member/view/ui/SignUpFragment.kt
+++ b/app/src/main/java/com/ite/sws/domain/member/view/ui/SignUpFragment.kt
@@ -14,14 +14,12 @@ class SignUpFragment : Fragment() {
 
     private var _binding: FragmentSignupBinding? = null
     private val binding get() = _binding!!
-    private lateinit var memberRepository: MemberRepository
+    private val memberRepository =  MemberRepository()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-
-        memberRepository = MemberRepository(requireContext())
 
         _binding = FragmentSignupBinding.inflate(inflater, container, false)
 

--- a/app/src/main/java/com/ite/sws/util/SharedPreferencesUtil.kt
+++ b/app/src/main/java/com/ite/sws/util/SharedPreferencesUtil.kt
@@ -18,6 +18,12 @@ import android.content.SharedPreferences
 object SharedPreferencesUtil {
 
     private const val PREFS_NAME = "auth_prefs"
+    private const val KEY_ACCESS_TOKEN = "ACCESS_TOKEN"
+    private lateinit var sharedPreferences: SharedPreferences
+
+    fun init(context: Context) {
+        sharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    }
 
     private fun getPreferences(context: Context): SharedPreferences {
         return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -74,5 +80,18 @@ object SharedPreferencesUtil {
         editor.clear()
         editor.apply()
     }
-}
 
+    /**
+     * 액세스 토큰 저장하기
+     */
+    fun setAccessToken(accessToken: String) {
+        sharedPreferences.edit().putString(KEY_ACCESS_TOKEN, accessToken).apply()
+    }
+
+    /**
+     * 액세스 토큰 가져오기
+     */
+    fun getAccessToken(): String? {
+        return sharedPreferences.getString(KEY_ACCESS_TOKEN, null)
+    }
+}

--- a/app/src/main/java/com/ite/sws/util/SharedPreferencesUtil.kt
+++ b/app/src/main/java/com/ite/sws/util/SharedPreferencesUtil.kt
@@ -13,6 +13,7 @@ import android.content.SharedPreferences
  * 수정일        	수정자        수정내용
  * ----------  --------    ---------------------------
  * 2024.08.31  	남진수       최초 생성
+ * 2024.09.03   정은지       액세스 토큰 저장 및 추출 함수 추가
  * </pre>
  */
 object SharedPreferencesUtil {

--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -20,6 +20,7 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toTopOf="@id/layout_login" />
 
+    <!-- 흰색 배경 -->
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/layout_login"
         android:layout_width="match_parent"
@@ -30,135 +31,149 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/layout_id"
-            android:layout_height="130dp"
-            android:layout_width="380dp"
-            android:background="@drawable/btn_white_shadow"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            android:padding="10dp"
-            android:layout_marginTop="70dp"
-            android:layout_marginHorizontal="@dimen/common_horizontal_margin">
-
-            <TextView
-                android:id="@+id/tv_id"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/fragment_login_id"
-                android:textSize="18sp"
-                android:fontFamily="@font/happiness_sans_bold"
-                android:textColor="@color/black"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                android:layout_marginTop="20dp"
-                android:layout_marginStart="20dp"
-                />
-
-            <!-- Nickname Input Field -->
-            <EditText
-                android:id="@+id/edt_id"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:hint="@string/fragment_login_hint_id"
-                android:inputType="text"
-                android:padding="12dp"
-                android:background="@android:color/transparent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/tv_id"
-                android:layout_marginTop="4dp"
-                android:layout_marginStart="10dp"
-                android:layout_marginEnd="10dp"
-                />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/password_card"
-            android:layout_height="130dp"
-            android:layout_width="380dp"
-            android:background="@drawable/btn_white_shadow"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/layout_id"
-            android:padding="10dp"
-            android:layout_marginTop="10dp"
-            android:layout_marginHorizontal="40dp">
-
-            <TextView
-                android:id="@+id/tv_password"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/fragment_login_password"
-                android:textSize="18sp"
-                android:fontFamily="@font/happiness_sans_bold"
-                android:textColor="@color/black"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                android:layout_marginTop="20dp"
-                android:layout_marginStart="20dp"
-                />
-
-            <EditText
-                android:id="@+id/edt_password"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:hint="@string/fragment_login_hint_password"
-                android:inputType="textPassword"
-                android:padding="12dp"
-                android:background="@android:color/transparent"
-                android:paddingHorizontal="0dp"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/tv_password"
-                android:layout_marginTop="4dp"
-                android:layout_marginStart="10dp"
-                android:layout_marginEnd="10dp"
-                />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <Button
-            android:id="@+id/btn_login"
+        <ScrollView
             android:layout_width="match_parent"
-            android:layout_height="70dp"
-            android:background="@drawable/btn_rounded_main"
-            android:text="@string/fragment_login"
-            android:textSize="20sp"
-            android:textColor="@color/white"
-            android:textFontWeight="1000"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/password_card"
-            android:layout_marginTop="20dp"
-            android:layout_marginHorizontal="30dp"/>
+            android:layout_height="0dp"
+            android:layout_marginTop="80dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
 
-        <TextView
-            android:id="@+id/tv_signup_comment"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/fragment_login_signup_comment"
-            android:textColor="@color/black"
-            android:layout_marginTop="40dp"
-            android:textFontWeight="700"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/btn_login" />
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/layout_scroll_inner"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:paddingBottom="50dp">
 
-        <TextView
-            android:id="@+id/tv_signup"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="5dp"
-            android:textColor="@color/main"
-            android:text="@string/fragment_login_signup"
-            android:textSize="18sp"
-            android:textFontWeight="1000"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_signup_comment" />
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/layout_id"
+                    android:layout_width="380dp"
+                    android:layout_height="130dp"
+                    android:layout_marginHorizontal="@dimen/common_horizontal_margin"
+                    android:layout_marginTop="10dp"
+                    android:background="@drawable/btn_white_shadow"
+                    android:padding="10dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent">
 
+                    <TextView
+                        android:id="@+id/tv_id"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="20dp"
+                        android:layout_marginTop="20dp"
+                        android:text="@string/fragment_login_id"
+                        android:textColor="@color/black"
+                        android:textFontWeight="1000"
+                        android:textSize="18sp"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                    <EditText
+                        android:id="@+id/edt_id"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="10dp"
+                        android:layout_marginTop="4dp"
+                        android:layout_marginEnd="10dp"
+                        android:background="@android:color/transparent"
+                        android:hint="@string/fragment_login_hint_id"
+                        android:inputType="text"
+                        android:padding="12dp"
+                        android:textColor="@color/gray"
+                        android:textFontWeight="700"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@+id/tv_id" />
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/password_card"
+                    android:layout_width="380dp"
+                    android:layout_height="130dp"
+                    android:layout_marginHorizontal="40dp"
+                    android:layout_marginTop="10dp"
+                    android:background="@drawable/btn_white_shadow"
+                    android:padding="10dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/layout_id">
+
+                    <TextView
+                        android:id="@+id/tv_password"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="20dp"
+                        android:layout_marginTop="20dp"
+                        android:text="@string/fragment_login_password"
+                        android:textColor="@color/black"
+                        android:textFontWeight="1000"
+                        android:textSize="18sp"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                    <EditText
+                        android:id="@+id/edt_password"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="10dp"
+                        android:layout_marginTop="4dp"
+                        android:layout_marginEnd="10dp"
+                        android:background="@android:color/transparent"
+                        android:hint="@string/fragment_login_hint_password"
+                        android:inputType="textPassword"
+                        android:padding="12dp"
+                        android:paddingHorizontal="0dp"
+                        android:textColor="@color/gray"
+                        android:textFontWeight="700"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@+id/tv_password" />
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+                <Button
+                    android:id="@+id/btn_login"
+                    android:layout_width="match_parent"
+                    android:layout_height="70dp"
+                    android:layout_marginHorizontal="30dp"
+                    android:layout_marginTop="20dp"
+                    android:background="@drawable/btn_rounded_main"
+                    android:text="@string/fragment_login"
+                    android:textAllCaps="false"
+                    android:textColor="@color/white"
+                    android:textFontWeight="1000"
+                    android:textSize="20sp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/password_card" />
+
+                <TextView
+                    android:id="@+id/tv_signup_comment"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="40dp"
+                    android:text="@string/fragment_login_signup_comment"
+                    android:textColor="@color/black"
+                    android:textFontWeight="700"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/btn_login" />
+
+                <TextView
+                    android:id="@+id/tv_signup"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="5dp"
+                    android:text="@string/fragment_login_signup"
+                    android:textColor="@color/main"
+                    android:textFontWeight="1000"
+                    android:textSize="18sp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_signup_comment" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </ScrollView>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_my_review.xml
+++ b/app/src/main/res/layout/fragment_my_review.xml
@@ -3,9 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/layout_review"
-    tools:context=".domain.member.view.ui.MyReviewFragment">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <TextView
         android:id="@+id/textView2"
@@ -15,5 +13,4 @@
         tools:layout_editor_absoluteX="216dp"
         tools:layout_editor_absoluteY="334dp"
         tools:ignore="MissingConstraints" />
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_mypage.xml
+++ b/app/src/main/res/layout/fragment_mypage.xml
@@ -21,13 +21,6 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"/>
 
-    <Button
-        android:id="@+id/login"
-        android:layout_width="100dp"
-        android:layout_height="100dp"
-        android:text="로그인 테스트"
-        tools:ignore="MissingConstraints" />
-
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"


### PR DESCRIPTION
## ✨ 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
- 로그인 UI 수정 (스크롤바 적용)
- 미로그인 사용자가 앱 접근 시 로그인 프래그먼트로 이동
- 회원 정보 조회 API 추가
- 레트로핏 인터셉터 설정

## 🍀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

## 🍰 참고 사항
API 호출할 때 AccessToken 있으면 헤더에 추가되니 따로 안 담아주셔도 됩니당~
@wlstnam SharedPreferencesUtil에 액세스 토큰 가져오고 설정하는 함수 따로 만들어 놨습니다! 

## 📷 스크린샷 또는 GIF
- 로그인 스크롤바 설정
  ![nse-4284631850314409151-9280](https://github.com/user-attachments/assets/effa7f18-940d-4f55-81e2-829b767ed995)

## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
