### PR TITLE
[SWS-149] 리프레시 토큰을 이용한 액세스 토큰 재발급

### DIFF
--- a/app/src/main/java/com/ite/sws/common/RetrofitClient.kt
+++ b/app/src/main/java/com/ite/sws/common/RetrofitClient.kt
@@ -1,7 +1,15 @@
 package com.ite.sws.common
 
+import android.util.Log
+import androidx.lifecycle.ViewModelProvider.NewInstanceFactory.Companion.instance
+import com.google.gson.Gson
 import com.ite.sws.BuildConfig
 import com.google.gson.GsonBuilder
+import com.ite.sws.BuildConfig.BASE_URL
+import com.ite.sws.common.RetrofitClient.httpClient
+import com.ite.sws.common.data.ErrorRes
+import com.ite.sws.domain.member.api.repository.MemberRepository
+import com.ite.sws.domain.member.api.service.MemberService
 import com.ite.sws.util.SharedPreferencesUtil
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -19,28 +27,68 @@ import retrofit2.converter.gson.GsonConverterFactory
  * ----------  --------    ---------------------------
  * 2024.08.31  	정은지       최초 생성
  * 2024.09.02   정은지       인터셉터 설정
- *
+ * 2024.09.13   정은지       액세스 토큰 재발급 추가
  * </pre>
  */
 
 object RetrofitClient {
     private const val BASE_URL = BuildConfig.BASE_URL
+    private val memberService: MemberService by lazy {
+        instance.create(MemberService::class.java)
+    }
 
-    // OkHttpClient 설정
     val httpClient: OkHttpClient by lazy {
         OkHttpClient.Builder()
             .addInterceptor { chain ->
-                val requestBuilder: Request.Builder = chain.request().newBuilder()
+                var request = chain.request()
+
                 // SharedPreferencesUtil에서 액세스 토큰 가져오기
                 val accessToken = SharedPreferencesUtil.getAccessToken()
-                // 액세스 토큰이 있으면 헤더에 추가
+                Log.d("RetrofitClient", "accessToken: $accessToken")
+
+                // 액세스 토큰이 있으면 Authorization 헤더에 추가
                 if (!accessToken.isNullOrEmpty()) {
-                    requestBuilder.addHeader("Authorization", "Bearer $accessToken")
+                    request = request.newBuilder()
+                        .header("Authorization", "Bearer $accessToken")
+                        .build()
                 }
-                chain.proceed(requestBuilder.build())
+
+                val response = chain.proceed(request)
+                Log.d("RetrofitClient", "Response message 확인: ${response.message}")
+                //  응답이 발생하면 리프레시 토큰을 사용해 액세스 토큰 재발급
+                if (response.code == 401) {
+                    // 리프레시 토큰 가져오기
+                    val refreshToken = SharedPreferencesUtil.getRefreshToken()
+
+                    if (!refreshToken.isNullOrEmpty()) {
+                        // 액세스 토큰 재발급 요청
+                        val newAccessTokenResponse = memberService.reissueAccessToken("Bearer $refreshToken").execute()
+
+                        // 재발급 성공 시
+                        if (newAccessTokenResponse.isSuccessful) {
+
+                            val newAccessToken = newAccessTokenResponse.headers()["Authorization"]?.replace("Bearer ", "")
+                            if (!newAccessToken.isNullOrEmpty()) {
+                                // 새 액세스 토큰을 SharedPreferences에 저장
+                                SharedPreferencesUtil.setAccessToken(newAccessToken)
+
+                                // 재발급된 액세스 토큰으로 기존 요청을 다시 실행
+                                val newRequest = request.newBuilder()
+                                    .header("Authorization", "Bearer $newAccessToken")
+                                    .build()
+
+                                // 재요청 실행
+                                return@addInterceptor chain.proceed(newRequest)
+                            }
+                        }
+                    }
+                }
+                // 원래 응답 반환
+                response
             }
             .build()
     }
+
 
     val instance: Retrofit by lazy {
         Retrofit.Builder()

--- a/app/src/main/java/com/ite/sws/domain/member/api/service/MemberService.kt
+++ b/app/src/main/java/com/ite/sws/domain/member/api/service/MemberService.kt
@@ -37,6 +37,7 @@ import retrofit2.http.Query
  * 2024.09.05   정은지        회원 구매 내역 조회 API 호출
  * 2024.09.06   정은지        작성 리뷰 조회 API 호출
  * 2024.09.10   남진수        FCM 토큰 발급 추가
+ * 2024.09.12   정은지        액세스 토큰 재발급 API 호출
  * </pre>
  */
 interface MemberService {
@@ -57,13 +58,13 @@ interface MemberService {
      * 로그아웃
      */
     @POST("/members/logout")
-    fun logout(): Call<Void>
+    fun logout(@Header("X-Refresh-Token") refreshToken: String): Call<Void>
 
     /**
      * 회원탈퇴
      */
     @DELETE("/members")
-    fun withdraw(): Call<Void>
+    fun withdraw(@Header("X-Refresh-Token") refreshToken: String): Call<Void>
 
     /**
      * 회원가입
@@ -98,4 +99,10 @@ interface MemberService {
         @Query("page") page: Int,
         @Query("size") size: Int
     ): Response<List<GetMemberReviewRes>>
+
+    /**
+     * 액세스 토큰 재발급
+     */
+    @POST("/members/reissue")
+    fun reissueAccessToken(@Header("X-Refresh-Token") refreshToken: String): Call<Void>
 }

--- a/app/src/main/java/com/ite/sws/domain/member/data/PostLoginRes.kt
+++ b/app/src/main/java/com/ite/sws/domain/member/data/PostLoginRes.kt
@@ -14,5 +14,6 @@ package com.ite.sws.domain.member.data
  */
 data class PostLoginRes (
     val cartId: Long,
-    val token: String? = null
+    val accessToken: String? = null,
+    val refreshToken: String? = null
 )

--- a/app/src/main/java/com/ite/sws/util/SharedPreferencesUtil.kt
+++ b/app/src/main/java/com/ite/sws/util/SharedPreferencesUtil.kt
@@ -15,12 +15,14 @@ import android.content.SharedPreferences
  * 2024.08.31  	남진수       최초 생성
  * 2024.09.03   정은지       액세스 토큰 관련 함수 추가
  * 2024.09.03   정은지       장바구니 아이디 관련 함수 추가
+ * 2024.09.12   정은지       리프레시 토큰 관련 함수 추가
  * </pre>
  */
 object SharedPreferencesUtil {
 
     private const val PREFS_NAME = "auth_prefs"
     private const val KEY_ACCESS_TOKEN = "ACCESS_TOKEN"
+    private const val KEY_REFRESH_TOKEN = "REFRESH_TOKEN"
     private const val KEY_CART_ID = "CART_ID"
     private const val KEY_CART_MEMBER_NAME = "NAME"
     private lateinit var sharedPreferences: SharedPreferences
@@ -139,5 +141,26 @@ object SharedPreferencesUtil {
      */
     fun getCartMemberName(): String? {
         return sharedPreferences.getString(KEY_CART_MEMBER_NAME, "")
+    }
+
+    /**
+     * 리프레시 토큰 저장
+     */
+    fun setRefreshToken(refreshToken: String) {
+        sharedPreferences.edit().putString(KEY_REFRESH_TOKEN, refreshToken).apply()
+    }
+
+    /**
+     * 리프레시 토큰 가져오기
+     */
+    fun getRefreshToken(): String? {
+        return sharedPreferences.getString(KEY_REFRESH_TOKEN, null)
+    }
+
+    /**
+     * 리프레시 토큰 삭제
+     */
+    fun removeRefreshToken() {
+        sharedPreferences.edit().remove(KEY_REFRESH_TOKEN).apply()
     }
 }


### PR DESCRIPTION
## ✨ 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
- 리프레시 토큰을 이용한 액세스 토큰 재발급 

## 🍀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

## 🍰 참고 사항
로그인 시 액세스 토큰과 리프레시 토큰을 모두 SharedPreference에 저장하고, Retrofit API 통신 과정에서 액세스 토큰이 만료되어 401 에러가 발생할 시 재발급 해주는 방식으로 적용하였습니다. 

## 📷 스크린샷 또는 GIF

## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
